### PR TITLE
Repair emscripten wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/setup-node@v3
       - name: prepare
         run: |
-          python -m pip install pyodide-build==${{ matrix.pyodide }} "pydantic>=1,<2"
+          python -m pip install pyodide-build==${{ matrix.pyodide }}
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
           PYODIDE_EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
@@ -147,6 +147,7 @@ jobs:
           export SKBUILD_CMAKE_DEFINE=TAT_MATH_LIBRARIES=$PWD/.pyodide-xbuildenv/xbuildenv/pyodide-root/packages/.libs/lib/${{ matrix.lapack }}
           export CMAKE_BUILD_PARALLEL_LEVEL=4
           pyodide build --exports pyinit
+          pyodide auditwheel repair dist/*.whl --libdir .pyodide-xbuildenv/xbuildenv/pyodide-root/packages/.libs/lib
       - name: test
         run: |
           cd PyTAT

--- a/PyTAT/test_wasm.js
+++ b/PyTAT/test_wasm.js
@@ -2,31 +2,35 @@
 "use strict";
 
 async function main() {
-    const fs = require("fs");
     const process = require("process");
-    const path = require("path");
 
     const pyodide = await require("pyodide").loadPyodide();
-    await pyodide.loadPackage(["scipy", "pytest"]);
-    // clapack/openblas should be loaded manually before loading TAT
-    // but some version of pyodide use clapack but other use openblas
-    // load scipy directly since it always depend on clapack or openblas
-    const dist_dir = "dist";
-    const files = await fs.promises.readdir(dist_dir);
-    await pyodide.loadPackage(path.join(dist_dir, files[0]));
+    await pyodide.loadPackage("micropip");
 
-    const mount_dir = "/tests";
+    const mount_dir = "/app";
     pyodide.FS.mkdir(mount_dir);
     pyodide.FS.mount(pyodide.FS.filesystems.NODEFS, {
-        root: "tests"
+        root: "."
     }, mount_dir);
-    const result = await pyodide.runPython(`
-import TAT
-print(TAT())
 
-import pytest
-pytest.main(["${mount_dir}"])
-    `);
+    const result = await pyodide.runPython(`
+async def main():
+    import micropip
+
+    import os
+    files = os.listdir("/app/dist")
+    await micropip.install(f"emfs:/app/dist/{files[0]}")
+
+    import TAT
+    print(TAT())
+
+    await micropip.install("pytest")
+    import pytest
+    return pytest.main(["/app/tests"])
+
+
+main()
+`);
     process.exit(result);
 }
 main();


### PR DESCRIPTION
The package openblas and numpy should be dependence of PyTAT. But currently pyodide cannot resolve it correctly. I am asking it in https://github.com/pyodide/pyodide/discussions/4340 and https://github.com/pyodide/pyodide/discussions/4344 .

Openblas is currently embedded in the wheel, which is OK. But numpy, as a dependency, cannot be installed autoamtically when I pyodide.loadPackage the wheel of PyTAT, which is confusing.

- [x] As for numpy, we should add it as real dependency, which can be loaded automatically when TAT is loaded. Using micropip.install instead of pyodide.loadPacakge solves it.
- [x] As for openblas, current embedding is acceptable, but a better solution is to add it as dependency just like numpy. see https://github.com/pyodide/pyodide/discussions/4340#discussioncomment-7896211 , we cannot specify the dependency for out-of-tree building.
- [ ] After building repair the wheel, program raise an error saying `Error: Dynamic linking error: cannot resolve symbol dgemm_`, I post it at https://github.com/ryanking13/auditwheel-emscripten/issues/24, waiting for solution.