### PR TITLE
[tet.py] Add support for trace hamiltonian on repeated points automatically.

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,17 @@
 + *tetragono*: Add =__contains__= and =__len__= for hamiltonians handle of abstract state.
 + *bridge*: Add support for bridging from TNSP new format.
 + *tetragono*: Stop saving configuration for ergodic sampling method during gradient descent.
++ *tetragono*: Add support for tracing repeated points when setting hamiltonian term. To use this feature, call
+  =state.hamiltonians.trace_repeated= after all the hamiltonian term has been set. For those term which will not be
+  traced, user could exchange the edge indices and points at the same time. For example a tensor with edges name as
+  =[O0, I0, O1, I1]= on points =(0,0,0)= and =(0,0,1)=, we can rename the tensor edge to =[O1, I1, O0, I0]= (it is
+  rename, not transpose!), and apply it to points =(0,0,1)= and =(0,0,0)=, and the system does not change. But for terms
+  which may be traced, we cannot exchange them. The order of edge indices hint the rule how to trace if points
+  duplicated.
++ *tetragono*: Add support to combine hamiltonian terms on the same group of points with different orders by
+  =sort_points=, which make the program faster for simple update and exact update.
++ *tetragono*: Add support to check whether the hamiltonians is hermitian by =check_hermite(threshold)=, which requires
+  =sort_points= invoked first.
 *** Changed
 + *TAT.py*: Use =scikit-build-core= as build backend. =MAKEFLAGS= and =CMAKEFLAGS= are droped. Use =scikit-build-core=
   environment variable =SKBUILD_CMAKE_ARGS= to pass arguments to cmake command line when building =PyTAT= wheel.

--- a/tetragono/tetragono/tensor_element.py
+++ b/tetragono/tetragono/tensor_element.py
@@ -16,11 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# this will never be pickled
-element_pool = {}
 
-
-def tensor_element(tensor):
+def tensor_element(tensor, element_pool={}):
     tensor_id = id(tensor)
     if tensor_id not in element_pool:
         element_pool[tensor_id] = calculate_element(tensor)

--- a/tetragono/tetragono/utility.py
+++ b/tetragono/tetragono/utility.py
@@ -350,3 +350,64 @@ def read_configurations(file_name):
     file.Read_at(offset, config)
     file.Close()
     return config
+
+
+def trace_repeated(tensor, points, trace_repeated_pool={}):
+    result = tensor
+
+    uniques = []
+    # points[i] == uniques[points_to_uniques[i]]
+    points_to_uniques = []
+    # uniques[i] == points[uniques_to_points[i]], the minimum of all possible value
+    uniques_to_points = []
+    for index_in_points, point in enumerate(points):
+        if point in uniques:
+            # Point Apprear before
+            index_in_uniques = uniques.index(point)
+            points_to_uniques.append(index_in_uniques)
+        else:
+            # First time for point
+            points_to_uniques.append(len(uniques))
+            uniques_to_points.append(index_in_points)
+            uniques.append(point)
+
+    key = (id(tensor), tuple(points_to_uniques))
+    if key not in trace_repeated_pool:
+        # 1. trace all same points
+        # 2. rename to same points
+        # 3. rename to lower index
+        trace_set = set()
+        rename_map = {}
+        for index_in_uniques, _ in enumerate(uniques):
+            # Find all point
+            index_of_group = [
+                index_in_points for index_in_points, another_index_in_uniques in enumerate(points_to_uniques)
+                if another_index_in_uniques == index_in_uniques
+            ]
+            for former, latter in zip(index_of_group[:-1], index_of_group[1:]):
+                trace_set.add((f"I{former}", f"O{latter}"))
+            rename_map[f"I{index_of_group[-1]}"] = f"I{index_of_group[0]}"
+        result = result.trace(trace_set)
+        result = result.edge_rename(rename_map)
+        result = result.edge_rename({
+            f"{direction}{index_in_points}": f"{direction}{index_in_uniques}"
+            for index_in_uniques, index_in_points in enumerate(uniques_to_points) for direction in ["I", "O"]
+        })
+        # tensor must be refered here, otherwise, id(tensor) may be invalid if tensor destructed.
+        trace_repeated_pool[key] = (tensor, result)
+
+    return trace_repeated_pool[key][1], tuple(uniques)
+
+
+def sort_points(tensor, points, sort_points_pool={}):
+    sorted_points = tuple(sorted(points))
+    order = tuple(sorted_points.index(point) for point in points)
+    key = (id(tensor), order)
+    if key not in sort_points_pool:
+        sorted_tensor = tensor.edge_rename({
+            f"{direction}{index_before}": f"{direction}{index_after}" for index_before, index_after in enumerate(order)
+            for direction in ["I", "O"]
+        })
+        # tensor must be refered here, otherwise, id(tensor) may be invalid if tensor destructed.
+        sort_points_pool[key] = (tensor, sorted_tensor)
+    return sort_points_pool[key][1], sorted_points


### PR DESCRIPTION
Add support for setting hamiltonian with which points duplicated, them the hamiltonian term will be traced automatically. For example, a two body term `tensor_{ij} = c_i^\dagger c_j`, can be applied to the same point, and it will be traced to be `tensor_i = c_i^\dagger c_i = n_i`.

- [ ] Everythings seems work, merge it after testing sjdong's new model.